### PR TITLE
fix fastqc report link

### DIFF
--- a/assembly-tutorial.md
+++ b/assembly-tutorial.md
@@ -76,7 +76,7 @@ cp ecoli/final.contigs.fa > ecoli-assembly.fa
 If you look at this assembly with 'head', you'll see it's a bunch of
 FASTA sequences.  How do you look at it comprehensively?
 
-Try running [quast](http://http://quast.sourceforge.net/quast):
+Try running [quast](http://quast.sourceforge.net/quast):
 
 ```
 quast.py ecoli-assembly.fa -o ecoli_report

--- a/assembly-tutorial.md
+++ b/assembly-tutorial.md
@@ -55,7 +55,7 @@ download from the console.  Open the zip file on your local computer,
 and find the file `ecoli_ref-5m_fastqc.html`. Double click on that.
 
 This is a
-[FastQC report](www.bioinformatics.babraham.ac.uk/projects/fastqc/)
+[FastQC report](http://www.bioinformatics.babraham.ac.uk/projects/fastqc/)
 that gives you a basic report on the quality of your sequencing.
 
 ## Looking at your assembly: mapping


### PR DESCRIPTION
without http:// the link is broken

also fixing the quast link
